### PR TITLE
Feat/organise and refactor theme using qt native methods

### DIFF
--- a/picard/__init__.py
+++ b/picard/__init__.py
@@ -42,7 +42,7 @@ PICARD_APP_NAME = "Picard"
 PICARD_DISPLAY_NAME = "MusicBrainz Picard"
 PICARD_APP_ID = "org.musicbrainz.Picard"
 PICARD_DESKTOP_NAME = PICARD_APP_ID + ".desktop"
-PICARD_VERSION = Version(3, 0, 0, 'dev', 6)
+PICARD_VERSION = Version(3, 0, 0, 'dev', 7)
 
 
 # optional build version

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -62,6 +62,8 @@ from picard.version import (
     VersionError,
 )
 
+from picard.ui.theme import UiTheme
+
 
 # All upgrade functions have to start with following prefix
 UPGRADE_FUNCTION_PREFIX = 'upgrade_to_v'
@@ -573,6 +575,12 @@ def upgrade_to_v3_0_0dev6(config):
     """New independent option "standardize_vocals" should use the value of the old shared option"""
     standardize_instruments_and_vocals = config.setting['standardize_instruments']
     config.setting['standardize_vocals'] = standardize_instruments_and_vocals
+
+
+def upgrade_to_v3_0_0dev7(config):
+    """Change theme option SYSTEM to DEFAULT"""
+    if config.setting['ui_theme'] == "system":
+        config.setting['ui_theme'] = UiTheme.DEFAULT
 
 
 def rename_option(config, old_opt, new_opt, option_type, default):

--- a/picard/config_upgrade.py
+++ b/picard/config_upgrade.py
@@ -385,11 +385,9 @@ def upgrade_to_v2_6_0beta2(config):
 
 def upgrade_to_v2_6_0beta3(config):
     """Replace use_system_theme with ui_theme options"""
-    from picard.ui.theme import UiTheme
-
     _s = config.setting
     if _s.value('use_system_theme', BoolOption):
-        _s['ui_theme'] = str(UiTheme.SYSTEM)
+        _s['ui_theme'] = 'system'
     _s.remove('use_system_theme')
 
 

--- a/picard/ui/options/interface.py
+++ b/picard/ui/options/interface.py
@@ -97,10 +97,6 @@ class InterfaceOptionsPage(OptionsPage):
             'label': N_("Light"),
             'desc': N_("A light display theme"),
         },
-        UiTheme.SYSTEM: {
-            'label': N_("System"),
-            'desc': N_("The Qt6 theme configured in the desktop environment"),
-        },
     }
 
     def __init__(self, parent=None):

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -86,7 +86,6 @@ class UiTheme(Enum):
     DEFAULT = 'default'
     DARK = 'dark'
     LIGHT = 'light'
-    SYSTEM = 'system'
 
     def __str__(self):
         return self.value
@@ -197,8 +196,8 @@ class BaseTheme:
         self._loaded_config_theme = UiTheme(config.setting['ui_theme'])
 
         # Use the new fusion style from PyQt6 for a modern and consistent look
-        # across all OSes, except when using system default theme on Linux.
-        if not IS_MACOS and not IS_HAIKU and not (not IS_WIN and self._loaded_config_theme == UiTheme.DEFAULT):
+        # across all OSes, except for macOS and Haiku.
+        if not IS_MACOS and not IS_HAIKU:
             app.setStyle('Fusion')
         elif IS_MACOS:
             app.setStyle(MacOverrideStyle(app.style()))
@@ -215,7 +214,7 @@ class BaseTheme:
             elif self._loaded_config_theme == UiTheme.LIGHT:
                 set_color_scheme(QtCore.Qt.ColorScheme.Light)
             else:
-                # For DEFAULT and SYSTEM themes, let Qt follow system settings
+                # For DEFAULT theme, let Qt follow system settings
                 set_color_scheme(QtCore.Qt.ColorScheme.Unknown)
 
         palette = QtGui.QPalette(app.palette())

--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -168,9 +168,11 @@ def apply_dark_theme_to_palette(palette: QtGui.QPalette):
     style_hints = get_style_hints()
     if style_hints is not None:
         style_hints.setColorScheme(QtCore.Qt.ColorScheme.Dark)
-    else:
-        # Fall back to manually applying dark colors
-        apply_dark_palette_colors(palette)
+        # Test whether the change was successful
+        if style_hints.colorScheme() == QtCore.Qt.ColorScheme.Dark:
+            return
+    # Fall back to manually applying dark colors
+    apply_dark_palette_colors(palette)
 
 
 class BaseTheme:

--- a/test/test_config_upgrade.py
+++ b/test/test_config_upgrade.py
@@ -69,11 +69,13 @@ from picard.config_upgrade import (
     upgrade_to_v3_0_0dev3,
     upgrade_to_v3_0_0dev4,
     upgrade_to_v3_0_0dev5,
+    upgrade_to_v3_0_0dev7,
 )
 from picard.const.defaults import (
     DEFAULT_FILE_NAMING_FORMAT,
     DEFAULT_REPLACEMENT,
     DEFAULT_SCRIPT_NAME,
+    DEFAULT_THEME_NAME,
 )
 from picard.util import unique_numbered_title
 from picard.version import Version
@@ -561,3 +563,9 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
             self.config.setting['replace_dir_separator'] = os.altsep
             upgrade_to_v3_0_0dev5(self.config)
             self.assertEqual(DEFAULT_REPLACEMENT, self.config.setting['replace_dir_separator'])
+
+    def test_upgrade_to_v3_0_0dev7(self):
+        TextOption('setting', 'ui_theme', DEFAULT_THEME_NAME)
+        self.config.setting['ui_theme'] = 'system'
+        upgrade_to_v3_0_0dev7(self.config)
+        self.assertEqual(DEFAULT_THEME_NAME, self.config.setting['ui_theme'])

--- a/test/test_config_upgrade.py
+++ b/test/test_config_upgrade.py
@@ -446,7 +446,7 @@ class TestPicardConfigUpgrades(TestPicardConfigCommon):
         upgrade_to_v2_6_0beta3(self.config)
         self.assertNotIn('use_system_theme', self.config.setting)
         self.assertIn('ui_theme', self.config.setting)
-        self.assertEqual(str(UiTheme.SYSTEM), self.config.setting['ui_theme'])
+        self.assertEqual('system', self.config.setting['ui_theme'])
 
     def test_upgrade_to_v2_7_0dev3(self):
         # Legacy settings

--- a/test/test_theme_stylehints.py
+++ b/test/test_theme_stylehints.py
@@ -306,7 +306,6 @@ class TestLinuxDarkModeDetection:
             ("default", False, False),  # Should not apply dark theme
             ("dark", True, False),  # Should not apply (already dark)
             ("light", True, False),  # Should not apply (explicit light)
-            ("system", True, False),  # Should not apply (system theme)
         ],
     )
     def test_linux_dark_mode_detection_logic(


### PR DESCRIPTION
This adds a config migration to change ui_theme "SYSTEM" to "DEFAULT".

Also fully removes UiTheme.SYSTEM. This was effectively already unused in the changes from https://github.com/metabrainz/picard/pull/2693/ , but was still tested for. As part of this applying the Fusion style on all platforms except for macOS and Haiku is restored.

