### PR TITLE
UI suggestions

### DIFF
--- a/picard/ui/itemviews/custom_columns/manager_dialog.py
+++ b/picard/ui/itemviews/custom_columns/manager_dialog.py
@@ -414,19 +414,19 @@ class CustomColumnsManagerDialog(PicardDialog):
         middle_v = QtWidgets.QVBoxLayout(self._editor_panel)
         form = QtWidgets.QFormLayout()
 
-        self._title = QtWidgets.QLineEdit()
-        self._key = QtWidgets.QLineEdit()
+        self._title = QtWidgets.QLineEdit(self._editor_panel)
+        self._key = QtWidgets.QLineEdit(self._editor_panel)
         self._key.setPlaceholderText(_("Auto-derived from Column Title"))
         self._expression = ScriptTextEdit(self)
         self._expression.setPlaceholderText("%artist% - %title%")
-        self._width = QtWidgets.QSpinBox()
+        self._width = QtWidgets.QSpinBox(self._editor_panel)
         self._width.setRange(DialogConfig.MIN_WIDTH, DialogConfig.MAX_WIDTH)
         self._width.setSpecialValueText("")
         self._width.setValue(DialogConfig.DEFAULT_WIDTH)
         self._width.setMaximumWidth(100)
         self._width.setAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
         self._width.setSuffix(_(' px'))
-        self._align = QtWidgets.QComboBox()
+        self._align = QtWidgets.QComboBox(self._editor_panel)
         for label, enum_val in get_align_options():
             self._align.addItem(label, enum_val)
         self._align.setMaximumWidth(100)
@@ -440,6 +440,15 @@ class CustomColumnsManagerDialog(PicardDialog):
         form.addRow(_("Align"), self._align)
         form.addRow(_("Add to views"), self._view_selector)
 
+        middle_v.addLayout(form)
+
+        # Add label for error message
+        self.error_message = QtWidgets.QLabel()
+        self.error_message.setStyleSheet("")
+        self.error_message.setText("")
+
+        middle_v.addWidget(self.error_message)
+
         # Add button at bottom of middle pane
         self._btn_add = QtWidgets.QPushButton(_("Add"), self._editor_panel)
         self._btn_add.clicked.connect(self._on_add)
@@ -447,12 +456,6 @@ class CustomColumnsManagerDialog(PicardDialog):
         add_row.addStretch(1)
         add_row.addWidget(self._btn_add)
 
-        self.error_message = QtWidgets.QLabel()
-        self.error_message.setStyleSheet("")
-        self.error_message.setText("")
-
-        middle_v.addLayout(form)
-        middle_v.addWidget(self.error_message)
         middle_v.addLayout(add_row)
 
         # Right: docs

--- a/picard/ui/itemviews/custom_columns/manager_dialog.py
+++ b/picard/ui/itemviews/custom_columns/manager_dialog.py
@@ -419,9 +419,13 @@ class CustomColumnsManagerDialog(PicardDialog):
         self._width.setRange(DialogConfig.MIN_WIDTH, DialogConfig.MAX_WIDTH)
         self._width.setSpecialValueText("")
         self._width.setValue(DialogConfig.DEFAULT_WIDTH)
+        self._width.setMaximumWidth(100)
+        self._width.setAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
+        self._width.setSuffix(_(' px'))
         self._align = QtWidgets.QComboBox(self._editor_panel)
         for label, enum_val in get_align_options():
             self._align.addItem(label, enum_val)
+        self._align.setMaximumWidth(100)
 
         self._view_selector = ViewSelector(self._editor_panel)
 

--- a/picard/ui/itemviews/custom_columns/manager_dialog.py
+++ b/picard/ui/itemviews/custom_columns/manager_dialog.py
@@ -31,12 +31,12 @@ columns. Internally, storage still supports multiple kinds.
 
 from __future__ import annotations
 
+import itertools
 from contextlib import contextmanager
 from dataclasses import (
     dataclass,
     replace,
 )
-import itertools
 
 from PyQt6 import (
     QtCore,
@@ -50,7 +50,7 @@ from picard.script.parser import (
     ScriptError,
     ScriptParser,
 )
-
+from picard.ui import PicardDialog
 from picard.ui.itemviews.custom_columns.shared import (
     DEFAULT_ADD_TO,
     format_add_to,
@@ -372,7 +372,7 @@ class _SpecListModel(QtCore.QAbstractListModel):
         return -1
 
 
-class CustomColumnsManagerDialog(QtWidgets.QDialog):
+class CustomColumnsManagerDialog(PicardDialog):
     """Single-window UI to manage custom columns."""
 
     def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
@@ -444,6 +444,7 @@ class CustomColumnsManagerDialog(QtWidgets.QDialog):
 
         # Splitter
         self._splitter = QtWidgets.QSplitter(self)
+        self._splitter.setObjectName('column_manager_splitter')
         self._splitter.setOrientation(QtCore.Qt.Orientation.Horizontal)
         self._splitter.addWidget(left_panel)
         self._splitter.addWidget(self._editor_panel)
@@ -841,3 +842,6 @@ class CustomColumnsManagerDialog(QtWidgets.QDialog):
             yield
         finally:
             self._populating = old
+
+    def closeEvent(self, event):
+        super().closeEvent(event)

--- a/picard/ui/itemviews/custom_columns/manager_dialog.py
+++ b/picard/ui/itemviews/custom_columns/manager_dialog.py
@@ -32,7 +32,10 @@ columns. Internally, storage still supports multiple kinds.
 from __future__ import annotations
 
 from contextlib import contextmanager
-from dataclasses import dataclass, replace
+from dataclasses import (
+    dataclass,
+    replace,
+)
 import itertools
 
 from PyQt6 import (
@@ -43,7 +46,10 @@ from PyQt6 import (
 from picard import log
 from picard.config import get_config
 from picard.i18n import gettext as _
-from picard.script.parser import ScriptError, ScriptParser
+from picard.script.parser import (
+    ScriptError,
+    ScriptParser,
+)
 
 from picard.ui.itemviews.custom_columns.shared import (
     DEFAULT_ADD_TO,

--- a/picard/ui/itemviews/custom_columns/manager_dialog.py
+++ b/picard/ui/itemviews/custom_columns/manager_dialog.py
@@ -461,10 +461,12 @@ class CustomColumnsManagerDialog(PicardDialog):
         self._buttonbox.addButton(
             StandardButton(StandardButton.CANCEL), QtWidgets.QDialogButtonBox.ButtonRole.RejectRole
         )
+        self._buttonbox.addButton(StandardButton(StandardButton.HELP), QtWidgets.QDialogButtonBox.ButtonRole.HelpRole)
         self._btn_apply = ok
 
         self._buttonbox.accepted.connect(self.accept)
         self._buttonbox.rejected.connect(self.reject)
+        self._buttonbox.helpRequested.connect(self.help)
 
         layout = QtWidgets.QVBoxLayout(self)
         layout.addWidget(self._splitter)
@@ -505,6 +507,10 @@ class CustomColumnsManagerDialog(PicardDialog):
         """Close the dialog discarding unsaved changes."""
         self._dirty = False
         super().reject()
+
+    def help(self) -> None:
+        """Open the online help page."""
+        self.show_help('/usage/custom_columns.html')
 
     # List / form coordination
     def _selected_row(self) -> int:

--- a/picard/ui/widgets/configurablecolumnsheader.py
+++ b/picard/ui/widgets/configurablecolumnsheader.py
@@ -117,7 +117,7 @@ class ConfigurableColumnsHeader(LockableHeaderView):
             dlg = CustomColumnsManagerDialog(parent=self)
             dlg.exec()
 
-        manage_action = QtGui.QAction(_("Manage Columns…"), menu)
+        manage_action = QtGui.QAction(_("Manage Custom Columns…"), menu)
         manage_action.setEnabled(not self.is_locked and CustomColumnsManagerDialog is not None)
         manage_action.triggered.connect(_open_manager)
         menu.addAction(manage_action)


### PR DESCRIPTION
Separate commits for each of the following to allow for easier cherry picking if desired:

- Fix import formatting
- Use `PicardDialog` to automatically save and restore the window layout
- Add a "Help" button to open the appropriate page in the online Picard User Guide
- Clarify in the header context menu that the option is to manage the custom columns only
- Resize and cosmetic changes to the width and alignment selectors
- Add real-time script checks during editing
